### PR TITLE
fix(p1): tooltip clamping, resize handler, localStorage safety, mobile nav dismiss

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script>try{const t=localStorage.getItem('theme')||'dark';if(t==='dark')document.documentElement.classList.add('dark')}catch(e){document.documentElement.classList.add('dark')}</script>
+    <script>try{const t=localStorage.getItem('theme')||(window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');if(t==='dark')document.documentElement.classList.add('dark')}catch(e){document.documentElement.classList.add('dark')}</script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes" />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Sun, Moon } from "lucide-react";
 import { motion } from "motion/react";
 import {
@@ -24,6 +24,28 @@ const navItems = [
 export default function TopNav() {
     const [isNavOpen, setIsNavOpen] = useState(false);
     const { theme, toggle } = useTheme();
+    const mobileNavRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!isNavOpen) return;
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setIsNavOpen(false);
+        };
+        const handleOutsideClick = (e: MouseEvent) => {
+            if (
+                mobileNavRef.current &&
+                !mobileNavRef.current.contains(e.target as Node)
+            ) {
+                setIsNavOpen(false);
+            }
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        document.addEventListener("mousedown", handleOutsideClick);
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            document.removeEventListener("mousedown", handleOutsideClick);
+        };
+    }, [isNavOpen]);
 
     return (
         <>
@@ -33,6 +55,7 @@ export default function TopNav() {
                 </NavBody>
 
                 <MobileNav>
+                    <div ref={mobileNavRef} className="w-full">
                     <MobileNavHeader>
                         <MobileNavToggle
                             isOpen={isNavOpen}
@@ -51,6 +74,7 @@ export default function TopNav() {
                             </a>
                         ))}
                     </MobileNavMenu>
+                    </div>
                 </MobileNav>
             </Navbar>
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -23,7 +23,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         } else {
             root.classList.remove("dark");
         }
-        localStorage.setItem("theme", theme);
+        try {
+            localStorage.setItem("theme", theme);
+        } catch {}
     }, [theme]);
 
     const toggle = () => setTheme((t) => (t === "dark" ? "light" : "dark"));

--- a/src/sections/About/GithubCalendar.tsx
+++ b/src/sections/About/GithubCalendar.tsx
@@ -86,7 +86,13 @@ export default function GithubCalendar() {
             {tooltip && (
                 <div
                     className="fixed z-50 pointer-events-none px-2.5 py-1.5 rounded-lg bg-[#F8F5F2] dark:bg-[#2e2e2e] border border-[#385144]/25 dark:border-[#C2D8C4]/15 text-xs text-[#1f3329] dark:text-[#C2D8C4] shadow-lg whitespace-nowrap"
-                    style={{ left: tooltip.x + 12, top: tooltip.y - 36 }}
+                    style={{
+                        left: Math.min(
+                            window.innerWidth - 220,
+                            tooltip.x + 12
+                        ),
+                        top: Math.max(8, tooltip.y - 36),
+                    }}
                 >
                     {tooltip.content}
                 </div>

--- a/src/sections/Hobbies/Hobbies.tsx
+++ b/src/sections/Hobbies/Hobbies.tsx
@@ -11,8 +11,15 @@ export default function Hobbies() {
         width: 400,
         height: 500,
     });
+    const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
     const touchStartX = useRef(0);
     const touchStartY = useRef(0);
+
+    useEffect(() => {
+        const handler = () => setViewportWidth(window.innerWidth);
+        window.addEventListener("resize", handler);
+        return () => window.removeEventListener("resize", handler);
+    }, []);
 
     const photos = [
         { title: "Skiing", src: "/photos/experience/barcelona/Barcelona.webp" },
@@ -225,7 +232,7 @@ export default function Hobbies() {
                             style={{
                                 width: Math.min(
                                     displayWidth + 40,
-                                    window.innerWidth - 32
+                                    viewportWidth - 32
                                 ),
                             }}
                         >


### PR DESCRIPTION
## Summary

- `GithubCalendar`: clamp tooltip position so it never overflows viewport edges
- `Hobbies`: add resize listener to keep carousel dimensions in sync with viewport
- `ThemeContext`: wrap `localStorage.setItem` in try/catch (matches existing getter safety)
- `Navbar`: add Escape key + outside-click dismissal for mobile menu
- `index.html`: theme script checks `prefers-color-scheme` before defaulting to dark

## Test plan

- [ ] Hover calendar cells near right/bottom edge — tooltip stays on screen
- [ ] Resize window while Hobbies carousel is open — layout adjusts
- [ ] Toggle theme in Safari private mode — no crash
- [ ] Open mobile nav, press Escape → closes; click outside → closes
- [ ] Open site with no `localStorage` and system set to light mode → loads in light theme