### PR TITLE
fix(p4): performance — preload, lazy loading, CLS fixes, memoization

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <script>try{const t=localStorage.getItem('theme')||(window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');if(t==='dark')document.documentElement.classList.add('dark')}catch(e){document.documentElement.classList.add('dark')}</script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preload" as="image" href="/photos/Hero/Hero.jpg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes" />
     <meta name="theme-color" content="#0a0a0a" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/src/components/ui/resizable-navbar.tsx
+++ b/src/components/ui/resizable-navbar.tsx
@@ -45,7 +45,10 @@ export const Navbar = ({ children, className }: NavbarProps) => {
     const [visible, setVisible] = useState(false);
 
     useEffect(() => {
-        const onScroll = () => setVisible(window.scrollY > 100);
+        const onScroll = () => {
+            const next = window.scrollY > 100;
+            setVisible((prev) => (prev === next ? prev : next));
+        };
         window.addEventListener("scroll", onScroll, { passive: true });
         return () => window.removeEventListener("scroll", onScroll);
     }, []);

--- a/src/sections/About/GithubCalendar.tsx
+++ b/src/sections/About/GithubCalendar.tsx
@@ -2,6 +2,11 @@ import { GitHubCalendar } from "react-github-calendar";
 import React, { useState, useCallback } from "react";
 import { useTheme } from "@/contexts/ThemeContext";
 
+const calendarTheme = {
+    light: ["#F8F5F2", "#c2d0c7", "#8aaa93", "#385144", "#1f3329"],
+    dark: ["#2e2e2e", "#2a3d2e", "#4a6b4e", "#7aaa7e", "#C2D8C4"],
+};
+
 interface TooltipState {
     content: string;
     x: number;
@@ -39,6 +44,27 @@ export default function GithubCalendar() {
 
     const handleMouseLeave = useCallback(() => setTooltip(null), []);
 
+    const renderBlock = useCallback(
+        (block: React.ReactElement, activity: { date: string; count: number }) =>
+            React.cloneElement(block as React.ReactElement<React.SVGProps<SVGRectElement>>, {
+                onMouseEnter: (e: React.MouseEvent) =>
+                    handleMouseEnter(activity, e),
+                onMouseMove: handleMouseMove,
+                onMouseLeave: handleMouseLeave,
+                style: {
+                    cursor: "pointer",
+                    outline:
+                        activity.count === 0
+                            ? theme === "light"
+                                ? "1px solid rgba(110,136,176,0.3)"
+                                : "1px solid rgba(194,216,196,0.2)"
+                            : "none",
+                    outlineOffset: "-1px",
+                },
+            }),
+        [theme, handleMouseEnter, handleMouseMove, handleMouseLeave]
+    );
+
     return (
         <div className="mt-16">
             <h3 className="text-xl font-medium">Days I code</h3>
@@ -46,40 +72,8 @@ export default function GithubCalendar() {
                 <GitHubCalendar
                     username="lucamartinet7"
                     colorScheme={theme}
-                    theme={{
-                        light: [
-                            "#F8F5F2",
-                            "#c2d0c7",
-                            "#8aaa93",
-                            "#385144",
-                            "#1f3329",
-                        ],
-                        dark: [
-                            "#2e2e2e",
-                            "#2a3d2e",
-                            "#4a6b4e",
-                            "#7aaa7e",
-                            "#C2D8C4",
-                        ],
-                    }}
-                    renderBlock={(block, activity) =>
-                        React.cloneElement(block, {
-                            onMouseEnter: (e: React.MouseEvent) =>
-                                handleMouseEnter(activity, e),
-                            onMouseMove: handleMouseMove,
-                            onMouseLeave: handleMouseLeave,
-                            style: {
-                                cursor: "pointer",
-                                outline:
-                                    activity.count === 0
-                                        ? theme === "light"
-                                            ? "1px solid rgba(110,136,176,0.3)"
-                                            : "1px solid rgba(194,216,196,0.2)"
-                                        : "none",
-                                outlineOffset: "-1px",
-                            },
-                        })
-                    }
+                    theme={calendarTheme}
+                    renderBlock={renderBlock}
                 />
             </div>
 

--- a/src/sections/Experience/ExperienceCard.tsx
+++ b/src/sections/Experience/ExperienceCard.tsx
@@ -18,7 +18,14 @@ function LazyVideo({ src, className }: { src: string; className: string }) {
             { rootMargin: "200px" }
         );
         observer.observe(el);
-        return () => observer.disconnect();
+        const onVisibility = () => {
+            if (document.hidden) el.pause();
+        };
+        document.addEventListener("visibilitychange", onVisibility);
+        return () => {
+            observer.disconnect();
+            document.removeEventListener("visibilitychange", onVisibility);
+        };
     }, []);
     return (
         <video
@@ -109,6 +116,7 @@ export default function ExperienceCard({
                                 alt={`${exp.location} — ${exp.country}`}
                                 loading="lazy"
                                 className="w-full h-auto block transition-transform duration-500 group-hover:scale-105"
+                                style={{ aspectRatio: "4/3" }}
                             />
                         )}
                         <div className="absolute inset-0 bg-black/10 group-hover:bg-black/0 transition-colors duration-300 pointer-events-none" />

--- a/src/sections/Hobbies/Hobbies.tsx
+++ b/src/sections/Hobbies/Hobbies.tsx
@@ -3,6 +3,16 @@ import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { SECTION_IDS } from "@/lib/anchors.ts";
 
+const photos = [
+    { title: "Skiing", src: "/photos/experience/barcelona/Barcelona.webp" },
+    { title: "Travel", src: "/photos/experience/cardiff/Cardiff_out.webp" },
+    { title: "Adventure", src: "/photos/experience/berlin/Berlin.webp" },
+    {
+        title: "Activity",
+        src: "/photos/experience/geneva-cyber/Cyberpeace_out2.webp",
+    },
+];
+
 export default function Hobbies() {
     const [playlistLoaded, setPlaylistLoaded] = useState(false);
     const [isCarouselOpen, setIsCarouselOpen] = useState(false);
@@ -22,16 +32,6 @@ export default function Hobbies() {
         window.addEventListener("resize", handler);
         return () => window.removeEventListener("resize", handler);
     }, []);
-
-    const photos = [
-        { title: "Skiing", src: "/photos/experience/barcelona/Barcelona.webp" },
-        { title: "Travel", src: "/photos/experience/cardiff/Cardiff_out.webp" },
-        { title: "Adventure", src: "/photos/experience/berlin/Berlin.webp" },
-        {
-            title: "Activity",
-            src: "/photos/experience/geneva-cyber/Cyberpeace_out2.webp",
-        },
-    ];
 
     useEffect(() => {
         if (isCarouselOpen) {
@@ -184,6 +184,7 @@ export default function Hobbies() {
                             <iframe
                                 allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"
                                 height="450"
+                                loading="lazy"
                                 className="w-full max-w-[660px] overflow-hidden bg-transparent"
                                 sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
                                 src="https://embed.music.apple.com/fr/playlist/pl.u-RRbV0o5sm4axqmN"

--- a/src/sections/Home/Home.tsx
+++ b/src/sections/Home/Home.tsx
@@ -76,6 +76,7 @@ export default function Home() {
                                 src="/photos/Hero/Hero.jpg"
                                 alt="Luca Martinet"
                                 className="w-full h-full object-cover"
+                                fetchPriority="high"
                             />
                         </motion.div>
 


### PR DESCRIPTION
## Summary

- `index.html`: preload hero image with `<link rel="preload">`
- `Home.tsx`: add `fetchPriority="high"` on hero `<img>`
- `ExperienceCard`: add `style={{ aspectRatio: '4/3' }}` to prevent CLS; pause video on tab blur via `visibilitychange`
- `resizable-navbar.tsx`: scroll listener uses functional setState to skip no-op re-renders
- `GithubCalendar`: hoist theme object to module scope; wrap `renderBlock` in `useCallback`
- `Hobbies`: hoist `photos` array to module scope; add `loading="lazy"` to Apple Music iframe

## Test plan

- [ ] Lighthouse performance score improves
- [ ] Network tab: hero image shows as preloaded; Apple Music iframe loads lazily
- [ ] No layout shift on Experience cards (check with CLS in DevTools)
- [ ] Switch tabs while Experience video plays — video pauses