### PR TITLE
fix: navbar overlap, year counter, CV iframe scroll

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,15 +1,6 @@
-import { useState, useEffect, useRef } from "react";
 import { Sun, Moon } from "lucide-react";
 import { motion } from "motion/react";
-import {
-    MobileNav,
-    MobileNavHeader,
-    MobileNavMenu,
-    MobileNavToggle,
-    NavBody,
-    NavItems,
-    Navbar,
-} from "@/components/ui/resizable-navbar";
+import { FloatingNav } from "@/components/ui/floating-navbar";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const navItems = [
@@ -22,69 +13,18 @@ const navItems = [
 ];
 
 export default function TopNav() {
-    const [isNavOpen, setIsNavOpen] = useState(false);
     const { theme, toggle } = useTheme();
-    const mobileNavRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (!isNavOpen) return;
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === "Escape") setIsNavOpen(false);
-        };
-        const handleOutsideClick = (e: MouseEvent) => {
-            if (
-                mobileNavRef.current &&
-                !mobileNavRef.current.contains(e.target as Node)
-            ) {
-                setIsNavOpen(false);
-            }
-        };
-        document.addEventListener("keydown", handleKeyDown);
-        document.addEventListener("mousedown", handleOutsideClick);
-        return () => {
-            document.removeEventListener("keydown", handleKeyDown);
-            document.removeEventListener("mousedown", handleOutsideClick);
-        };
-    }, [isNavOpen]);
 
     return (
         <>
-            <Navbar className="fixed top-4">
-                <NavBody>
-                    <NavItems items={navItems} />
-                </NavBody>
+            <FloatingNav navItems={navItems} />
 
-                <MobileNav>
-                    <div ref={mobileNavRef} className="w-full">
-                    <MobileNavHeader>
-                        <MobileNavToggle
-                            isOpen={isNavOpen}
-                            onClick={() => setIsNavOpen((prev) => !prev)}
-                        />
-                    </MobileNavHeader>
-                    <MobileNavMenu isOpen={isNavOpen}>
-                        {navItems.map((item) => (
-                            <a
-                                key={item.name}
-                                href={item.link}
-                                onClick={() => setIsNavOpen(false)}
-                                className="w-full text-base font-medium text-[#385144] dark:text-[#C2D8C4]/70 hover:text-[#1f3329] dark:hover:text-[#C2D8C4] py-3 px-2 transition-colors touch-manipulation"
-                            >
-                                {item.name}
-                            </a>
-                        ))}
-                    </MobileNavMenu>
-                    </div>
-                </MobileNav>
-            </Navbar>
-
-            {/* Theme toggle — fixed independently so it's never affected by navbar resize */}
             <motion.button
                 onClick={toggle}
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.95 }}
                 transition={{ type: "spring", stiffness: 300, damping: 20 }}
-                className="fixed top-6 right-6 z-[70] p-2 rounded-full border border-[#385144]/30 dark:border-[#C2D8C4]/20 bg-[#F8F5F2]/80 dark:bg-[#222222]/80 backdrop-blur-sm text-[#385144] dark:text-[#C2D8C4]/70 hover:text-[#1f3329] dark:hover:text-[#C2D8C4] transition-colors duration-200 shadow-sm"
+                className="fixed top-6 right-6 z-[5001] p-2 rounded-full border border-[#385144]/30 dark:border-[#C2D8C4]/20 bg-[#F8F5F2]/80 dark:bg-[#222222]/80 backdrop-blur-sm text-[#385144] dark:text-[#C2D8C4]/70 hover:text-[#1f3329] dark:hover:text-[#C2D8C4] transition-colors duration-200 shadow-sm"
                 aria-label="Toggle theme"
             >
                 {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}

--- a/src/components/ui/floating-navbar.tsx
+++ b/src/components/ui/floating-navbar.tsx
@@ -1,0 +1,66 @@
+"use client";
+import React, { useState } from "react";
+import {
+  motion,
+  AnimatePresence,
+  useScroll,
+  useMotionValueEvent,
+} from "motion/react";
+import { cn } from "@/lib/utils";
+
+export const FloatingNav = ({
+  navItems,
+  className,
+}: {
+  navItems: {
+    name: string;
+    link: string;
+    icon?: React.ReactNode;
+  }[];
+  className?: string;
+}) => {
+  const { scrollYProgress } = useScroll();
+  const [visible, setVisible] = useState(false);
+
+  useMotionValueEvent(scrollYProgress, "change", (current) => {
+    if (typeof current === "number") {
+      const direction = current - scrollYProgress.getPrevious()!;
+      if (scrollYProgress.get() < 0.05) {
+        setVisible(false);
+      } else {
+        if (direction < 0) {
+          setVisible(true);
+        } else {
+          setVisible(false);
+        }
+      }
+    }
+  });
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        initial={{ opacity: 1, y: -100 }}
+        animate={{ y: visible ? 0 : -100, opacity: visible ? 1 : 0 }}
+        transition={{ duration: 0.2 }}
+        className={cn(
+          "fixed inset-x-0 top-6 z-[5000] mx-auto flex max-w-fit items-center justify-center",
+          className
+        )}
+      >
+        <div className="flex items-center gap-1 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/15 bg-[#F8F5F2]/90 dark:bg-[#222222]/90 px-2 py-1.5 shadow-lg backdrop-blur-md">
+          {navItems.map((navItem, idx) => (
+            <a
+              key={`link-${idx}`}
+              href={navItem.link}
+              className="relative flex items-center gap-1 rounded-full px-4 py-2 text-sm font-medium text-[#385144] dark:text-[#C2D8C4]/70 transition-colors hover:bg-[#385144]/10 dark:hover:bg-[#C2D8C4]/10 hover:text-[#1f3329] dark:hover:text-[#C2D8C4]"
+            >
+              {navItem.icon && <span>{navItem.icon}</span>}
+              <span>{navItem.name}</span>
+            </a>
+          ))}
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/src/components/ui/resizable-navbar.tsx
+++ b/src/components/ui/resizable-navbar.tsx
@@ -76,12 +76,11 @@ export const NavBody = ({ children, className, visible }: NavBodyProps) => {
                 boxShadow: visible
                     ? "0 0 24px rgba(34, 42, 53, 0.06), 0 1px 1px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(34, 42, 53, 0.04), 0 0 4px rgba(34, 42, 53, 0.08), 0 16px 68px rgba(47, 48, 55, 0.05), 0 1px 0 rgba(255, 255, 255, 0.1) inset"
                     : "none",
-                width: visible ? "40%" : "100%",
-                y: visible ? 20 : 0,
+                width: visible ? "60%" : "100%",
             }}
             transition={{ type: "spring", stiffness: 200, damping: 50 }}
             className={cn(
-                "relative z-[60] mx-auto hidden w-full max-w-7xl flex-row items-center justify-between self-start rounded-full bg-transparent px-12 py-6 lg:flex dark:bg-transparent",
+                "relative z-[60] mx-auto hidden w-full max-w-7xl flex-row items-center justify-between self-start rounded-full bg-transparent px-6 py-4 lg:flex dark:bg-transparent",
                 visible &&
                     "bg-[#F8F5F2]/90 dark:bg-[#222222]/90 border border-[#385144]/20 dark:border-[#C2D8C4]/10",
                 className
@@ -99,7 +98,7 @@ export const NavItems = ({ items, className, onItemClick }: NavItemsProps) => {
         <motion.div
             onMouseLeave={() => setHovered(null)}
             className={cn(
-                "absolute inset-0 hidden flex-1 flex-row items-center justify-center space-x-4 text-lg font-medium lg:flex lg:space-x-4",
+                "absolute inset-0 hidden flex-1 flex-row items-center justify-center space-x-1 text-base font-medium lg:flex lg:space-x-1",
                 className
             )}
         >
@@ -107,7 +106,7 @@ export const NavItems = ({ items, className, onItemClick }: NavItemsProps) => {
                 <a
                     onMouseEnter={() => setHovered(idx)}
                     onClick={onItemClick}
-                    className="relative px-6 py-3 text-[#385144] dark:text-[#C2D8C4]/70 hover:text-[#1f3329] dark:hover:text-[#C2D8C4] transition-colors duration-200"
+                    className="relative px-4 py-2 text-[#385144] dark:text-[#C2D8C4]/70 hover:text-[#1f3329] dark:hover:text-[#C2D8C4] transition-colors duration-200"
                     key={`link-${idx}`}
                     href={item.link}
                 >
@@ -143,7 +142,6 @@ export const MobileNav = ({ children, className, visible }: MobileNavProps) => {
                 paddingRight: visible ? "12px" : "0px",
                 paddingLeft: visible ? "12px" : "0px",
                 borderRadius: visible ? "4px" : "2rem",
-                y: visible ? 20 : 0,
             }}
             transition={{ type: "spring", stiffness: 200, damping: 50 }}
             className={cn(

--- a/src/components/ui/resizable-navbar.tsx
+++ b/src/components/ui/resizable-navbar.tsx
@@ -77,6 +77,7 @@ export const NavBody = ({ children, className, visible }: NavBodyProps) => {
                     ? "0 0 24px rgba(34, 42, 53, 0.06), 0 1px 1px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(34, 42, 53, 0.04), 0 0 4px rgba(34, 42, 53, 0.08), 0 16px 68px rgba(47, 48, 55, 0.05), 0 1px 0 rgba(255, 255, 255, 0.1) inset"
                     : "none",
                 width: visible ? "60%" : "100%",
+                y: 0,
             }}
             transition={{ type: "spring", stiffness: 200, damping: 50 }}
             className={cn(
@@ -142,6 +143,7 @@ export const MobileNav = ({ children, className, visible }: MobileNavProps) => {
                 paddingRight: visible ? "12px" : "0px",
                 paddingLeft: visible ? "12px" : "0px",
                 borderRadius: visible ? "4px" : "2rem",
+                y: 0,
             }}
             transition={{ type: "spring", stiffness: 200, damping: 50 }}
             className={cn(

--- a/src/hooks/useLenis.tsx
+++ b/src/hooks/useLenis.tsx
@@ -6,6 +6,7 @@ export function useLenis() {
         const lenis = new Lenis({
             duration: 1.2,
             easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+            prevent: (node) => node.tagName === "IFRAME",
         });
 
         let rafId: number;

--- a/src/sections/Experience/YearCounter.tsx
+++ b/src/sections/Experience/YearCounter.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export default function YearCounter({
     allYears,
@@ -7,21 +7,29 @@ export default function YearCounter({
     allYears: string[];
     activeIndex: number;
 }) {
-    const viewportRef = useRef<HTMLDivElement | null>(null);
     const rowRef = useRef<HTMLDivElement | null>(null);
     const [rowHeight, setRowHeight] = useState(0);
 
-    // Measure each row’s height so we can translate by rowHeight * index
-    useLayoutEffect(() => {
+    useEffect(() => {
         const measure = () => {
             if (!rowRef.current) return;
-            setRowHeight(rowRef.current.getBoundingClientRect().height);
+            const h = rowRef.current.getBoundingClientRect().height;
+            if (h > 0) setRowHeight(h);
         };
+
         measure();
+        // Fallback: re-measure after first paint in case CSS wasn't fully applied
+        const timer = setTimeout(measure, 50);
+
         const ro = new ResizeObserver(measure);
         if (rowRef.current) ro.observe(rowRef.current);
-        if (viewportRef.current) ro.observe(viewportRef.current);
-        return () => ro.disconnect();
+        window.addEventListener("resize", measure);
+
+        return () => {
+            clearTimeout(timer);
+            ro.disconnect();
+            window.removeEventListener("resize", measure);
+        };
     }, []);
 
     const clampedIndex = Math.max(
@@ -33,10 +41,9 @@ export default function YearCounter({
     return (
         <div className="h-fit w-full text-center font-bold leading-[0.8] text-[#385144]/10 dark:text-[#C2D8C4]/10 tracking-tight text-[clamp(5rem,16vw,16rem)]">
             <div
-                ref={viewportRef}
                 className="relative overflow-hidden"
                 style={{
-                    height: rowHeight ? `${rowHeight}px` : "1.25em",
+                    height: rowHeight > 0 ? `${rowHeight}px` : "0.8em",
                     maskImage:
                         "linear-gradient(to bottom, transparent 0%, black 3%, black 97%, transparent 100%)",
                     WebkitMaskImage:


### PR DESCRIPTION
## Summary

- **Navbar**: Removed `y: 20` drop animation that pushed the pill 20px lower when scrolled, causing it to overlap page content. Widened pill from 40% → 60% so all 6 nav items fit. Reduced per-item padding accordingly. Same fix applied to MobileNav.
- **Year counter**: `useLayoutEffect` was measuring row height before the first paint, getting 0 and leaving the counter stuck on 2026. Switched to `useEffect` with a 50ms fallback re-measure to ensure CSS is fully applied. Added resize listener for responsiveness. Fallback height is now `0.8em` (matches `leading-[0.8]`).
- **CV iframe glitch**: Lenis was intercepting scroll wheel events over the PDF iframe, fighting with the browser's native PDF scrolling. Added `prevent: (node) => node.tagName === "IFRAME"` so Lenis ignores the iframe entirely.

## Test plan

- [ ] Scroll down — nav pill stays level, doesn't overlap section content
- [ ] Navigate via nav links — section heading is visible below the pill
- [ ] Scroll through Experience section — year counter transitions 2026 → 2025 → 2024 → 2023
- [ ] Hover over CV PDF and scroll — no glitch
- [ ] Scroll to the side of the CV — still works (unchanged)