### PR TITLE
redesign: Projects section (Figma mockup)

### DIFF
--- a/src/sections/Projects/ProjectCard.tsx
+++ b/src/sections/Projects/ProjectCard.tsx
@@ -1,103 +1,85 @@
-import { Github, ExternalLink } from "lucide-react";
+import { Github, ArrowUpRight, Star } from "lucide-react";
 import { motion } from "motion/react";
 import type { Project } from "./projects.data";
 
-type Props = { project: Project };
+type Props = { project: Project; featured?: boolean };
 
-const tagColors: Record<string, string> = {
-    "C++": "border-blue-500/30 bg-blue-500/10 text-blue-600 dark:text-blue-300",
-    Python: "border-yellow-500/30 bg-yellow-500/10 text-yellow-600 dark:text-yellow-300",
-    Dart: "border-cyan-500/30 bg-cyan-500/10 text-cyan-600 dark:text-cyan-300",
-    MySQL: "border-orange-500/30 bg-orange-500/10 text-orange-600 dark:text-orange-300",
-    Networking:
-        "border-violet-500/30 bg-violet-500/10 text-violet-600 dark:text-violet-300",
-    ECS: "border-pink-500/30 bg-pink-500/10 text-pink-600 dark:text-pink-300",
-    ML: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300",
-    Plugins:
-        "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300",
-};
-
-export default function ProjectCard({ project }: Props) {
+function Tags({ tags }: { tags?: string[] }) {
+    if (!tags?.length) return null;
     return (
-        <motion.article
-            whileHover={{ y: -4 }}
-            transition={{ type: "spring", stiffness: 300, damping: 24 }}
-            className="group relative rounded-2xl border border-[#385144]/20 dark:border-[#C2D8C4]/10 bg-[#385144]/5 dark:bg-[#C2D8C4]/[0.03] hover:bg-[#385144]/10 dark:hover:bg-[#C2D8C4]/[0.06] hover:border-[#385144]/30 dark:hover:border-[#C2D8C4]/20 transition-colors duration-300 overflow-hidden flex flex-col"
-        >
-            <div className="p-6 flex flex-col flex-1">
-                {/* Title row */}
+        <ul className="mt-4 flex flex-wrap gap-2">
+            {tags.map((t) => (
+                <li
+                    key={t}
+                    className="rounded-full border border-[#385144]/25 dark:border-[#C2D8C4]/15 bg-[#385144]/[0.07] dark:bg-[#C2D8C4]/[0.05] px-3 py-1 text-xs font-medium text-[#385144] dark:text-[#C2D8C4]/70"
+                >
+                    {t}
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+export default function ProjectCard({ project, featured }: Props) {
+    const href = project.demoUrl ?? project.githubUrl;
+
+    if (featured) {
+        return (
+            <motion.article
+                whileHover={{ y: -4 }}
+                transition={{ type: "spring", stiffness: 300, damping: 24 }}
+                className="rounded-2xl border-[1.5px] border-[#385144]/28 dark:border-[#C2D8C4]/20 bg-[#385144]/[0.04] dark:bg-[#C2D8C4]/[0.04] p-6 shadow-[0_8px_32px_-8px_rgba(56,81,68,0.18)] md:p-7"
+            >
                 <div className="flex items-start justify-between gap-4">
-                    <div>
-                        <h3 className="text-xl font-semibold leading-snug">
-                            {project.title}
-                        </h3>
-                    </div>
-                    <motion.a
-                        href={project.githubUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        whileHover={{ scale: 1.1, rotate: 8 }}
-                        whileTap={{ scale: 0.95 }}
-                        transition={{
-                            type: "spring",
-                            stiffness: 300,
-                            damping: 20,
-                        }}
-                        className="mt-1 shrink-0 text-[#385144]/40 dark:text-[#C2D8C4]/30 hover:text-[#385144] dark:hover:text-[#C2D8C4] transition-colors duration-200"
-                        aria-label={`${project.title} on GitHub`}
-                    >
-                        <Github size={18} />
-                    </motion.a>
-                </div>
-
-                <p className="mt-4 text-sm leading-relaxed text-neutral-600 dark:text-[#C2D8C4]/50 flex-1">
-                    {project.description}
-                </p>
-
-                {/* Tags */}
-                {!!project.tags?.length && (
-                    <ul className="mt-5 flex flex-wrap gap-2">
-                        {project.tags.map((t) => (
-                            <motion.li
-                                key={t}
-                                whileHover={{ scale: 1.08, y: -1 }}
-                                transition={{
-                                    type: "spring",
-                                    stiffness: 300,
-                                    damping: 20,
-                                }}
-                                className={`rounded-full border px-2.5 py-1 text-xs font-medium cursor-default ${tagColors[t] ?? "border-neutral-200 dark:border-white/10 bg-neutral-100 dark:bg-white/[0.04] text-neutral-500 dark:text-white/50"}`}
-                            >
-                                {t}
-                            </motion.li>
-                        ))}
-                    </ul>
-                )}
-
-                {/* Footer links */}
-                <div className="mt-6 pt-4 border-t border-[#385144]/10 dark:border-[#C2D8C4]/[0.06] flex items-center gap-4">
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/20 bg-[#385144]/10 dark:bg-[#C2D8C4]/10 px-3 py-1 text-xs font-semibold text-[#385144] dark:text-[#C2D8C4]">
+                        <Star size={12} className="fill-current" />
+                        Featured
+                    </span>
                     <a
                         href={project.githubUrl}
                         target="_blank"
                         rel="noreferrer"
-                        className="inline-flex items-center gap-1.5 text-xs font-medium text-[#385144]/60 dark:text-[#C2D8C4]/40 hover:text-[#385144] dark:hover:text-[#C2D8C4] transition-colors duration-200"
+                        className="inline-flex items-center gap-1.5 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/20 bg-[#385144]/[0.07] dark:bg-[#C2D8C4]/[0.05] px-3.5 py-1.5 text-[13px] font-medium text-[#385144] dark:text-[#C2D8C4]/80 transition-colors hover:bg-[#385144]/15 dark:hover:bg-[#C2D8C4]/10"
                     >
-                        <Github size={13} />
-                        View source
+                        <Github size={14} />
+                        GitHub
+                        <ArrowUpRight size={13} />
                     </a>
-                    {project.demoUrl && (
-                        <a
-                            href={project.demoUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="inline-flex items-center gap-1.5 text-xs font-medium text-[#385144]/60 dark:text-[#C2D8C4]/40 hover:text-[#385144] dark:hover:text-[#C2D8C4] transition-colors duration-200"
-                        >
-                            <ExternalLink size={13} />
-                            Live demo
-                        </a>
-                    )}
                 </div>
+
+                <h3 className="mt-5 text-xl font-bold text-[#111] dark:text-[#F8F5F2] md:text-2xl">
+                    {project.title}
+                </h3>
+                <p className="mt-3 max-w-2xl text-[15px] leading-relaxed text-neutral-600 dark:text-[#C2D8C4]/60">
+                    {project.description}
+                </p>
+                <Tags tags={project.tags} />
+            </motion.article>
+        );
+    }
+
+    return (
+        <motion.a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`${project.title} — open ${project.demoUrl ? "live demo" : "on GitHub"}`}
+            whileHover={{ y: -4 }}
+            transition={{ type: "spring", stiffness: 300, damping: 24 }}
+            className="group flex h-full flex-col rounded-2xl border border-[#385144]/14 dark:border-[#C2D8C4]/10 bg-[#385144]/[0.03] dark:bg-[#C2D8C4]/[0.03] p-5 transition-colors hover:border-[#385144]/25 dark:hover:border-[#C2D8C4]/20 hover:bg-[#385144]/[0.06] dark:hover:bg-[#C2D8C4]/[0.06]"
+        >
+            <div className="flex items-start justify-between gap-4">
+                <h3 className="text-base font-bold text-[#111] dark:text-[#F8F5F2]">
+                    {project.title}
+                </h3>
+                <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full border border-[#385144]/15 dark:border-[#C2D8C4]/15 bg-[#385144]/[0.07] dark:bg-[#C2D8C4]/[0.05] text-[#385144] dark:text-[#C2D8C4]/80 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5">
+                    <ArrowUpRight size={14} />
+                </span>
             </div>
-        </motion.article>
+            <p className="mt-2 flex-1 text-[13px] leading-relaxed text-neutral-600 dark:text-[#C2D8C4]/60">
+                {project.description}
+            </p>
+            <Tags tags={project.tags} />
+        </motion.a>
     );
 }

--- a/src/sections/Projects/Projects.tsx
+++ b/src/sections/Projects/Projects.tsx
@@ -1,34 +1,55 @@
 import ProjectCard from "./ProjectCard";
 import { projects } from "./projects.data";
-import GithubCalendar from "../About/GithubCalendar";
 import { SECTION_IDS } from "@/lib/anchors.ts";
 import { motion } from "motion/react";
 
 export default function Projects() {
+    const featured = projects.find((p) => p.featured);
+    const rest = projects.filter((p) => !p.featured);
+
     return (
-        <section id={SECTION_IDS.PROJECTS} className="px-6 py-16 md:py-32">
-            <div className="mx-auto max-w-6xl">
+        <section
+            id={SECTION_IDS.PROJECTS}
+            className="relative overflow-hidden px-6 py-16 md:py-32"
+        >
+            <div
+                aria-hidden
+                className="pointer-events-none absolute -right-32 top-0 h-[420px] w-[420px] rounded-full bg-[#385144]/[0.04] dark:bg-[#C2D8C4]/[0.04] blur-2xl"
+            />
+
+            <div className="relative mx-auto max-w-6xl">
                 <motion.header
-                    className="max-w-2xl"
                     initial={{ opacity: 0, y: 24 }}
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true, amount: 0.3 }}
                     transition={{ duration: 0.5, ease: "easeOut" }}
                 >
-                    <h2 className="text-3xl font-semibold">
-                        Selected{" "}
-                        <span className="text-[#385144] dark:text-[#C2D8C4]/60">
-                            Work
-                        </span>
+                    <p className="text-[11px] font-bold uppercase tracking-wider text-[#385144]/65 dark:text-[#C2D8C4]/50">
+                        Selected work
+                    </p>
+                    <div className="mt-1.5 h-[2px] w-11 rounded-full bg-[#385144]/30 dark:bg-[#C2D8C4]/25" />
+                    <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-[#111] dark:text-[#F8F5F2] md:text-5xl">
+                        Things I've built
                     </h2>
-                    <p className="mt-3 text-neutral-600 dark:text-[#C2D8C4]/60">
-                        A few projects I've built recently—systems work,
-                        networking, and web tooling.
+                    <p className="mt-3 text-base text-neutral-500 dark:text-[#C2D8C4]/50 md:text-lg">
+                        Systems, networking, and web tooling — all on GitHub.
                     </p>
                 </motion.header>
 
-                <div className="mt-12 grid grid-cols-1 md:grid-cols-2 gap-6">
-                    {projects.map((p, idx) => (
+                {featured && (
+                    <motion.div
+                        className="mt-12"
+                        initial={{ opacity: 0, y: 24 }}
+                        whileInView={{ opacity: 1, y: 0 }}
+                        viewport={{ once: true, amount: 0.2 }}
+                        transition={{ duration: 0.45, ease: "easeOut" }}
+                    >
+                        <ProjectCard project={featured} featured />
+                    </motion.div>
+                )}
+
+                <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+                    {rest.map((p, idx) => (
                         <motion.div
                             key={p.title}
                             initial={{ opacity: 0, y: 24 }}
@@ -44,16 +65,6 @@ export default function Projects() {
                         </motion.div>
                     ))}
                 </div>
-
-                <motion.div
-                    className="mt-16"
-                    initial={{ opacity: 0, y: 24 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    viewport={{ once: true, amount: 0.1 }}
-                    transition={{ duration: 0.5, ease: "easeOut" }}
-                >
-                    <GithubCalendar />
-                </motion.div>
             </div>
         </section>
     );

--- a/src/sections/Projects/projects.data.ts
+++ b/src/sections/Projects/projects.data.ts
@@ -1,44 +1,48 @@
 export type Project = {
     title: string;
     description: string;
-    image?: string;
     githubUrl: string;
     demoUrl?: string;
     tags?: string[];
-    accent: string; // tailwind bg color class for the accent
+    featured?: boolean;
 };
 
 export const projects: Project[] = [
     {
         title: "BeeR-Type (R-Type)",
         description:
-            "Multiplayer 2D shooter with modular server/client/engine architecture. Built with modern C++, ECS, and robust networking.",
+            "Multiplayer 2D shooter with modular server / client / engine architecture. Built with modern C++, ECS pattern, and UDP networking.",
         githubUrl: "https://github.com/lucamartinet7/R-Type",
         tags: ["C++", "Networking", "ECS"],
-        accent: "bg-blue-500",
+        featured: true,
     },
     {
         title: "AREA",
         description:
-            "IFTTT/Zapier-style automation platform with backend, web frontend, and mobile frontend.",
+            "IFTTT-style automation with backend, web, and mobile frontends.",
         githubUrl: "https://github.com/LucaMartinet7/Area-Tek3",
-        tags: ["Dart", "Python", "MySQL"],
-        accent: "bg-violet-500",
+        tags: ["Python", "Dart", "MySQL"],
     },
     {
         title: "Neural Network",
         description:
-            "Chessboard state analysis using a ML-based approach (project-focused implementation).",
+            "Chessboard state analysis via a custom ML-based pipeline.",
         githubUrl: "https://github.com/LucaMartinet7/Neural-Network",
         tags: ["Python", "ML"],
-        accent: "bg-emerald-500",
     },
     {
         title: "Arcade",
         description:
-            "Dynamic game platform with runtime-switchable graphics libraries and games loaded via shared objects.",
+            "Game platform with runtime-switchable graphics libs via shared objects.",
         githubUrl: "https://github.com/LucaMartinet7/Arcade",
         tags: ["C++", "Plugins"],
-        accent: "bg-orange-500",
+    },
+    {
+        title: "Portfolio",
+        description:
+            "React 19, TypeScript, Tailwind v4, Framer Motion, Lenis smooth scroll.",
+        githubUrl: "https://github.com/LucaMartinet7/Portfolio",
+        demoUrl: "https://lucamartinet.dev",
+        tags: ["React", "TypeScript"],
     },
 ];


### PR DESCRIPTION
## Summary
Fourth section of the portfolio redesign. Rebuilds **Projects** to match the Figma mockup.

- `SELECTED WORK` eyebrow + `Things I've built` heading and tagline
- Full-width **featured** card (BeeR-Type) with a ★ Featured badge and a GitHub pill
- 2-column grid of compact project cards, each linking out via a ↗ affordance
- Added the **Portfolio** site itself as a project (React / TypeScript), matching the mockup
- Uniform green tag pills (dropped the old multi-colour tag map)
- Removed the duplicate GitHub contribution calendar that was rendered here (it now lives in the About section)
- Dropped unused `accent` / `image` fields from the project data model

## Test plan
- [x] `tsc -b` passes
- [x] Verified in browser preview; layout matches Figma
- [x] Dark mode + responsive (grid collapses to 1 column on mobile)