### PR TITLE
redesign: add Contact section (Figma mockup)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useLenis } from "./hooks/useLenis";
 import Experience from "./sections/Experience";
 import Projects from "./sections/Projects";
 import About from "./sections/About";
+import Contact from "./sections/Contact";
 import TopNav from "./components/Navbar";
 import { ThemeProvider } from "./contexts/ThemeContext";
 
@@ -21,6 +22,8 @@ function Inner() {
             <Projects />
             <div className="py-8 md:py-12" />
             <Resume />
+            <div className="py-8 md:py-12" />
+            <Contact />
         </main>
     );
 }

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -8,4 +8,5 @@ export const SECTION_IDS = {
     EXPERIENCE: "experience",
     PROJECTS: "projects",
     RESUME: "resume",
+    CONTACT: "contact",
 } as const;

--- a/src/sections/Contact/Contact.tsx
+++ b/src/sections/Contact/Contact.tsx
@@ -1,0 +1,67 @@
+import { SECTION_IDS } from "@/lib/anchors.ts";
+import { motion } from "motion/react";
+import { Github, Linkedin, ArrowRight } from "lucide-react";
+
+const EMAIL = "lucamartinetwork@gmail.com";
+
+export default function Contact() {
+    return (
+        <section
+            id={SECTION_IDS.CONTACT}
+            className="relative overflow-hidden border-t border-[#385144]/10 dark:border-[#C2D8C4]/10 px-6 py-20 md:py-28"
+        >
+            <div
+                aria-hidden
+                className="pointer-events-none absolute left-1/2 top-0 h-[440px] w-[600px] -translate-x-1/2 rounded-full bg-[#385144]/[0.05] dark:bg-[#C2D8C4]/[0.04] blur-3xl"
+            />
+
+            <motion.div
+                className="relative mx-auto flex max-w-2xl flex-col items-center text-center"
+                initial={{ opacity: 0, y: 24 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ duration: 0.5, ease: "easeOut" }}
+            >
+                <h2 className="text-4xl font-extrabold tracking-tight text-[#111] dark:text-[#F8F5F2] md:text-6xl">
+                    Let's work together.
+                </h2>
+                <p className="mt-4 text-base text-neutral-500 dark:text-[#C2D8C4]/50 md:text-lg">
+                    Open to internships, collaborations, and interesting
+                    problems.
+                </p>
+
+                <motion.a
+                    href={`mailto:${EMAIL}`}
+                    whileHover={{ scale: 1.03, y: -1 }}
+                    whileTap={{ scale: 0.97 }}
+                    transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                    className="mt-9 inline-flex items-center gap-2 rounded-full bg-[#385144] px-7 py-3.5 text-sm font-semibold text-white shadow-[0_12px_32px_-8px_rgba(56,81,68,0.5)] transition-colors duration-200 hover:bg-[#1f3329] dark:bg-[#C2D8C4] dark:text-[#222222] dark:hover:bg-[#aecbb1] touch-manipulation"
+                >
+                    {EMAIL}
+                    <ArrowRight size={15} />
+                </motion.a>
+
+                <div className="mt-6 flex items-center gap-3">
+                    <a
+                        href="https://github.com/lucamartinet7"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1.5 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/20 bg-[#385144]/[0.07] dark:bg-[#C2D8C4]/[0.05] px-4 py-2 text-[13px] font-medium text-[#385144] dark:text-[#C2D8C4]/70 transition-colors hover:bg-[#385144]/15 dark:hover:bg-[#C2D8C4]/10 hover:text-[#1f3329] dark:hover:text-[#C2D8C4]"
+                    >
+                        <Github size={14} />
+                        GitHub
+                    </a>
+                    <a
+                        href="https://www.linkedin.com/in/luca-martinet/"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1.5 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/20 bg-[#385144]/[0.07] dark:bg-[#C2D8C4]/[0.05] px-4 py-2 text-[13px] font-medium text-[#385144] dark:text-[#C2D8C4]/70 transition-colors hover:bg-[#385144]/15 dark:hover:bg-[#C2D8C4]/10 hover:text-[#1f3329] dark:hover:text-[#C2D8C4]"
+                    >
+                        <Linkedin size={14} />
+                        LinkedIn
+                    </a>
+                </div>
+            </motion.div>
+        </section>
+    );
+}

--- a/src/sections/Contact/index.ts
+++ b/src/sections/Contact/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Contact";

--- a/src/sections/Home/Home.tsx
+++ b/src/sections/Home/Home.tsx
@@ -74,9 +74,7 @@ export default function Home() {
                             <ArrowDown size={15} />
                         </motion.a>
                         <motion.a
-                            href="https://www.linkedin.com/in/luca-martinet/"
-                            target="_blank"
-                            rel="noreferrer"
+                            href={`#${SECTION_IDS.CONTACT}`}
                             whileHover={{ scale: 1.03, y: -1 }}
                             whileTap={{ scale: 0.97 }}
                             transition={{ type: "spring", stiffness: 300, damping: 20 }}


### PR DESCRIPTION
## Summary
Adds the **Contact** section (⑥) from the Figma mockup, placed after Resume.

- Centered `Let's work together.` heading + tagline
- Green email CTA (`mailto:lucamartinetwork@gmail.com`) and GitHub / LinkedIn chips
- New `CONTACT` anchor constant
- Wired the Hero **Get in touch** button to scroll to `#contact` (previously a LinkedIn placeholder)

## Test plan
- [x] `tsc -b` passes
- [x] Verified in preview; matches Figma; dark mode + responsive