### PR TITLE
redesign: add Footer (Figma mockup)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Projects from "./sections/Projects";
 import About from "./sections/About";
 import Contact from "./sections/Contact";
 import TopNav from "./components/Navbar";
+import Footer from "./components/Footer";
 import { ThemeProvider } from "./contexts/ThemeContext";
 
 function Inner() {
@@ -24,6 +25,7 @@ function Inner() {
             <Resume />
             <div className="py-8 md:py-12" />
             <Contact />
+            <Footer />
         </main>
     );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,105 @@
+import { SECTION_IDS } from "@/lib/anchors.ts";
+
+const navLinks = [
+    { name: "About", href: `#${SECTION_IDS.ABOUT}` },
+    { name: "Experience", href: `#${SECTION_IDS.EXPERIENCE}` },
+    { name: "Projects", href: `#${SECTION_IDS.PROJECTS}` },
+    { name: "Resume", href: `#${SECTION_IDS.RESUME}` },
+];
+
+const contactLinks = [
+    { name: "GitHub", href: "https://github.com/lucamartinet7", external: true },
+    {
+        name: "LinkedIn",
+        href: "https://www.linkedin.com/in/luca-martinet/",
+        external: true,
+    },
+    { name: "Email", href: "mailto:lucamartinetwork@gmail.com", external: false },
+];
+
+export default function Footer() {
+    return (
+        <footer className="border-t border-white/[0.06] bg-[#151815] px-6 py-12 text-[#949494]">
+            <div className="mx-auto max-w-6xl">
+                <div className="grid gap-10 md:grid-cols-2">
+                    {/* Brand */}
+                    <div>
+                        <p className="text-2xl font-extrabold tracking-tight">
+                            <span className="text-white">Luca</span>{" "}
+                            <span className="text-[#c2d8c3]">Martinet</span>
+                        </p>
+                        <p className="mt-3 max-w-xs text-[13px] leading-relaxed">
+                            Software developer &amp; student at Epitech.
+                            Building from low-level C to full-stack web.
+                        </p>
+                        <span className="mt-4 inline-flex items-center gap-2 rounded-full border border-[#c2d8c3]/20 bg-[#c2d8c3]/[0.08] px-3 py-1.5">
+                            <span className="relative flex h-2 w-2">
+                                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#4ade80] opacity-60" />
+                                <span className="relative inline-flex h-2 w-2 rounded-full bg-[#4ade80]" />
+                            </span>
+                            <span className="text-xs font-medium text-[#c2d8c3]">
+                                Open to opportunities
+                            </span>
+                        </span>
+                    </div>
+
+                    {/* Link columns */}
+                    <div className="grid grid-cols-2 gap-8 md:justify-items-end">
+                        <nav>
+                            <p className="text-[10px] font-bold uppercase tracking-wider text-[#6b6b6b]">
+                                Navigation
+                            </p>
+                            <ul className="mt-3 space-y-2.5">
+                                {navLinks.map((link) => (
+                                    <li key={link.name}>
+                                        <a
+                                            href={link.href}
+                                            className="text-[13px] transition-colors hover:text-[#c2d8c3]"
+                                        >
+                                            {link.name}
+                                        </a>
+                                    </li>
+                                ))}
+                            </ul>
+                        </nav>
+
+                        <nav>
+                            <p className="text-[10px] font-bold uppercase tracking-wider text-[#6b6b6b]">
+                                Contact
+                            </p>
+                            <ul className="mt-3 space-y-2.5">
+                                {contactLinks.map((link) => (
+                                    <li key={link.name}>
+                                        <a
+                                            href={link.href}
+                                            target={
+                                                link.external
+                                                    ? "_blank"
+                                                    : undefined
+                                            }
+                                            rel={
+                                                link.external
+                                                    ? "noreferrer"
+                                                    : undefined
+                                            }
+                                            className="text-[13px] transition-colors hover:text-[#c2d8c3]"
+                                        >
+                                            {link.name}
+                                        </a>
+                                    </li>
+                                ))}
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
+
+                <div className="mt-10 flex flex-col gap-2 border-t border-white/[0.07] pt-6 text-xs text-[#5c5c5c] sm:flex-row sm:items-center sm:justify-between">
+                    <p>© 2026 Luca Martinet. All rights reserved.</p>
+                    <p className="text-[#c2d8c3]/60">
+                        Built with React &amp; Tailwind
+                    </p>
+                </div>
+            </div>
+        </footer>
+    );
+}


### PR DESCRIPTION
## Summary
Adds the **Footer** (⑦) from the Figma mockup — the final piece of the redesign.

- Dark footer with the `Luca Martinet` brand (green accent), bio, and an "Open to opportunities" status pill
- **Navigation** (About / Experience / Projects / Resume) and **Contact** (GitHub / LinkedIn / Email) link columns
- Bottom bar: `© 2026 Luca Martinet` + `Built with React & Tailwind`

## Test plan
- [x] `tsc -b` passes
- [x] Verified in preview; matches Figma; responsive (columns stack on mobile)