### PR TITLE
feat: respect prefers-reduced-motion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Contact from "./sections/Contact";
 import TopNav from "./components/Navbar";
 import Footer from "./components/Footer";
 import { ThemeProvider } from "./contexts/ThemeContext";
+import { MotionConfig } from "motion/react";
 
 function Inner() {
     useLenis();
@@ -33,7 +34,11 @@ function Inner() {
 export default function App() {
     return (
         <ThemeProvider>
-            <Inner />
+            {/* `reducedMotion="user"` makes every motion component respect the
+                OS "reduce motion" setting (transforms are skipped). */}
+            <MotionConfig reducedMotion="user">
+                <Inner />
+            </MotionConfig>
         </ThemeProvider>
     );
 }

--- a/src/hooks/useLenis.tsx
+++ b/src/hooks/useLenis.tsx
@@ -1,8 +1,41 @@
 import { useEffect } from "react";
 import Lenis from "lenis";
 
+const NAV_OFFSET = 96;
+
 export function useLenis() {
     useEffect(() => {
+        const prefersReducedMotion = window.matchMedia(
+            "(prefers-reduced-motion: reduce)"
+        ).matches;
+
+        const resolveAnchor = (event: MouseEvent) => {
+            const target = event.target as HTMLElement | null;
+            const anchor = target?.closest(
+                'a[href^="#"]'
+            ) as HTMLAnchorElement | null;
+            if (!anchor) return null;
+
+            const hash = anchor.getAttribute("href");
+            if (!hash || hash === "#") return null;
+
+            return document.querySelector(hash) as HTMLElement | null;
+        };
+
+        // Respect the user's "reduce motion" preference: skip Lenis smooth
+        // scrolling entirely and fall back to native instant anchor jumps.
+        if (prefersReducedMotion) {
+            const handleAnchorClick = (event: MouseEvent) => {
+                const section = resolveAnchor(event);
+                if (!section) return;
+                event.preventDefault();
+                window.scrollTo({ top: section.offsetTop - NAV_OFFSET });
+            };
+            document.addEventListener("click", handleAnchorClick);
+            return () =>
+                document.removeEventListener("click", handleAnchorClick);
+        }
+
         const lenis = new Lenis({
             duration: 1.2,
             easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
@@ -19,23 +52,10 @@ export function useLenis() {
         }
 
         const handleAnchorClick = (event: MouseEvent) => {
-            const target = event.target as HTMLElement | null;
-            const anchor = target?.closest(
-                'a[href^="#"]'
-            ) as HTMLAnchorElement | null;
-
-            if (!anchor) return;
-
-            const hash = anchor.getAttribute("href");
-
-            if (!hash || hash === "#") return;
-
-            const section = document.querySelector(hash);
-
+            const section = resolveAnchor(event);
             if (!section) return;
-
             event.preventDefault();
-            lenis.scrollTo(section as HTMLElement, { offset: -96 });
+            lenis.scrollTo(section, { offset: -NAV_OFFSET });
         };
 
         document.addEventListener("click", handleAnchorClick);


### PR DESCRIPTION
## Summary
Honors the OS-level **"reduce motion"** accessibility setting (WCAG 2.3.3), which the site previously ignored in JS.

- Wrap the app in `<MotionConfig reducedMotion="user">` so every Framer Motion component automatically drops transform/scale animations for users who prefer reduced motion (opacity transitions still apply).
- Gate **Lenis** in `useLenis`: when `prefers-reduced-motion: reduce` is set, skip smooth scrolling entirely and fall back to native instant anchor jumps. Otherwise unchanged.
- Extract the shared anchor-resolution helper and a `NAV_OFFSET` constant (removes the duplicated anchor logic).

## Test plan
- [x] `tsc -b` + `npm run lint` pass
- [x] Default path verified in preview — smooth anchor scroll lands exactly on target, no console errors
- [ ] Reduced-motion path (set OS "Reduce motion") → instant jumps, no slide-in animations