### PR TITLE
refactor: semantic brand color tokens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { MotionConfig } from "motion/react";
 function Inner() {
     useLenis();
     return (
-        <main className="bg-[#F8F5F2] dark:bg-[#222222] text-neutral-900 dark:text-[#C2D8C4] pt-20 md:pt-28 transition-colors duration-300">
+        <main className="bg-surface dark:bg-surface-dark text-neutral-900 dark:text-mint pt-20 md:pt-28 transition-colors duration-300">
             <TopNav />
             <Home />
             <div className="py-4 md:py-6" />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -27,15 +27,15 @@ export default function Footer() {
                     <div>
                         <p className="text-2xl font-extrabold tracking-tight">
                             <span className="text-white">Luca</span>{" "}
-                            <span className="text-[#c2d8c3]">Martinet</span>
+                            <span className="text-mint">Martinet</span>
                         </p>
                         <p className="mt-3 max-w-xs text-[13px] leading-relaxed">
                             Software developer &amp; student at Epitech.
                             Building from low-level C to full-stack web.
                         </p>
-                        <span className="mt-4 inline-flex items-center gap-2 rounded-full border border-[#c2d8c3]/20 bg-[#c2d8c3]/[0.08] px-3 py-1.5">
+                        <span className="mt-4 inline-flex items-center gap-2 rounded-full border border-mint/20 bg-mint/[0.08] px-3 py-1.5">
                             <PulseDot />
-                            <span className="text-xs font-medium text-[#c2d8c3]">
+                            <span className="text-xs font-medium text-mint">
                                 Open to opportunities
                             </span>
                         </span>
@@ -52,7 +52,7 @@ export default function Footer() {
                                     <li key={link.name}>
                                         <a
                                             href={link.href}
-                                            className="text-[13px] transition-colors hover:text-[#c2d8c3]"
+                                            className="text-[13px] transition-colors hover:text-mint"
                                         >
                                             {link.name}
                                         </a>
@@ -80,7 +80,7 @@ export default function Footer() {
                                                     ? "noreferrer"
                                                     : undefined
                                             }
-                                            className="text-[13px] transition-colors hover:text-[#c2d8c3]"
+                                            className="text-[13px] transition-colors hover:text-mint"
                                         >
                                             {link.name}
                                         </a>
@@ -93,7 +93,7 @@ export default function Footer() {
 
                 <div className="mt-10 flex flex-col gap-2 border-t border-white/[0.07] pt-6 text-xs text-[#5c5c5c] sm:flex-row sm:items-center sm:justify-between">
                     <p>© 2026 Luca Martinet. All rights reserved.</p>
-                    <p className="text-[#c2d8c3]/60">
+                    <p className="text-mint/60">
                         Built with React &amp; Tailwind
                     </p>
                 </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -23,7 +23,7 @@ export default function TopNav() {
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.95 }}
                 transition={{ type: "spring", stiffness: 300, damping: 20 }}
-                className="fixed top-6 right-6 z-[5001] p-2 rounded-full border border-[#385144]/30 dark:border-[#C2D8C4]/20 bg-[#F8F5F2]/80 dark:bg-[#222222]/80 backdrop-blur-sm text-[#385144] dark:text-[#C2D8C4]/70 hover:text-[#1f3329] dark:hover:text-[#C2D8C4] transition-colors duration-200 shadow-sm"
+                className="fixed top-6 right-6 z-[5001] p-2 rounded-full border border-brand/30 dark:border-mint/20 bg-surface/80 dark:bg-surface-dark/80 backdrop-blur-sm text-brand dark:text-mint/70 hover:text-brand-dark dark:hover:text-mint transition-colors duration-200 shadow-sm"
                 aria-label="Toggle theme"
             >
                 {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}

--- a/src/components/ui/floating-navbar.tsx
+++ b/src/components/ui/floating-navbar.tsx
@@ -39,12 +39,12 @@ export const FloatingNav = ({
           className
         )}
       >
-        <div className="flex items-center gap-1 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/15 bg-[#F8F5F2]/90 dark:bg-[#222222]/90 px-4 py-1.5 shadow-lg backdrop-blur-md">
+        <div className="flex items-center gap-1 rounded-full border border-brand/20 dark:border-mint/15 bg-surface/90 dark:bg-surface-dark/90 px-4 py-1.5 shadow-lg backdrop-blur-md">
           {navItems.map((navItem, idx) => (
             <a
               key={`link-${idx}`}
               href={navItem.link}
-              className="relative flex items-center gap-1 rounded-full px-4 py-2 text-sm font-medium text-[#385144] dark:text-[#C2D8C4]/70 transition-colors hover:bg-[#385144]/10 dark:hover:bg-[#C2D8C4]/10 hover:text-[#1f3329] dark:hover:text-[#C2D8C4]"
+              className="relative flex items-center gap-1 rounded-full px-4 py-2 text-sm font-medium text-brand dark:text-mint/70 transition-colors hover:bg-brand/10 dark:hover:bg-mint/10 hover:text-brand-dark dark:hover:text-mint"
             >
               {navItem.icon && <span>{navItem.icon}</span>}
               <span>{navItem.name}</span>

--- a/src/components/ui/primitives.tsx
+++ b/src/components/ui/primitives.tsx
@@ -40,10 +40,10 @@ export function Eyebrow({
 }) {
     return (
         <div className={className}>
-            <p className="text-[11px] font-bold uppercase tracking-wider text-[#385144]/65 dark:text-[#C2D8C4]/50">
+            <p className="text-[11px] font-bold uppercase tracking-wider text-brand/65 dark:text-mint/50">
                 {children}
             </p>
-            <div className="mt-1.5 h-[2px] w-11 rounded-full bg-[#385144]/30 dark:bg-[#C2D8C4]/25" />
+            <div className="mt-1.5 h-[2px] w-11 rounded-full bg-brand/30 dark:bg-mint/25" />
         </div>
     );
 }
@@ -64,7 +64,7 @@ export function GlowBlob({ className }: { className?: string }) {
         <div
             aria-hidden
             className={cn(
-                "pointer-events-none absolute rounded-full bg-[#385144]/[0.04] blur-2xl dark:bg-[#C2D8C4]/[0.04]",
+                "pointer-events-none absolute rounded-full bg-brand/[0.04] blur-2xl dark:bg-mint/[0.04]",
                 className
             )}
         />
@@ -84,7 +84,7 @@ export function Chip({
     children: ReactNode;
 }) {
     const base =
-        "inline-flex items-center gap-1.5 rounded-full border border-[#385144]/20 px-3.5 py-1.5 text-sm font-medium text-[#385144] dark:border-[#C2D8C4]/15 dark:text-[#C2D8C4]/70 bg-[#385144]/[0.07] dark:bg-[#C2D8C4]/[0.05]";
+        "inline-flex items-center gap-1.5 rounded-full border border-brand/20 px-3.5 py-1.5 text-sm font-medium text-brand dark:border-mint/15 dark:text-mint/70 bg-brand/[0.07] dark:bg-mint/[0.05]";
 
     if (href) {
         return (
@@ -94,7 +94,7 @@ export function Chip({
                 rel="noreferrer"
                 className={cn(
                     base,
-                    "transition-colors hover:bg-[#385144]/15 hover:text-[#1f3329] dark:hover:bg-[#C2D8C4]/10 dark:hover:text-[#C2D8C4]",
+                    "transition-colors hover:bg-brand/15 hover:text-brand-dark dark:hover:bg-mint/10 dark:hover:text-mint",
                     className
                 )}
             >
@@ -109,4 +109,4 @@ export function Chip({
 
 /** Primary green pill button styling, shared by CTA links. */
 export const primaryButtonClass =
-    "inline-flex items-center gap-2 rounded-full bg-[#385144] px-7 py-3.5 text-sm font-semibold text-white shadow-[0_12px_32px_-8px_rgba(56,81,68,0.5)] transition-colors duration-200 hover:bg-[#1f3329] dark:bg-[#C2D8C4] dark:text-[#222222] dark:hover:bg-[#aecbb1] touch-manipulation";
+    "inline-flex items-center gap-2 rounded-full bg-brand px-7 py-3.5 text-sm font-semibold text-white shadow-[0_12px_32px_-8px_rgba(56,81,68,0.5)] transition-colors duration-200 hover:bg-brand-dark dark:bg-mint dark:text-surface-dark dark:hover:bg-mint-hover touch-manipulation";

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,18 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Brand palette — semantic tokens so the colours live in one place and are
+   usable as Tailwind utilities (text-brand, bg-surface, border-mint/20, …). */
+@theme {
+    --color-brand: #385144;
+    --color-brand-dark: #1f3329;
+    --color-mint: #c2d8c4;
+    --color-mint-hover: #aecbb1;
+    --color-surface: #f8f5f2;
+    --color-surface-dark: #222222;
+    --color-ink: #111111;
+}
+
 .lenis.lenis-smooth [data-lenis-prevent] {
     overscroll-behavior: contain;
 }

--- a/src/sections/About/About.tsx
+++ b/src/sections/About/About.tsx
@@ -31,21 +31,21 @@ export default function About() {
                 >
                     <Eyebrow>About</Eyebrow>
 
-                    <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-[#111] dark:text-[#F8F5F2] md:text-5xl">
+                    <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-ink dark:text-surface md:text-5xl">
                         Who I am
                     </h2>
 
-                    <p className="mt-6 max-w-md text-base leading-7 text-neutral-600 dark:text-[#C2D8C4]/60 md:text-lg">
+                    <p className="mt-6 max-w-md text-base leading-7 text-neutral-600 dark:text-mint/60 md:text-lg">
                         I'm Luca, a software development student at Epitech. I
                         build reliable systems and ship real projects — from
                         low-level C to full-stack web applications.
                     </p>
 
-                    <blockquote className="mt-8 border-l-[3px] border-[#385144]/40 dark:border-[#C2D8C4]/25 pl-4">
-                        <p className="text-base italic leading-relaxed text-neutral-600 dark:text-[#C2D8C4]/70">
+                    <blockquote className="mt-8 border-l-[3px] border-brand/40 dark:border-mint/25 pl-4">
+                        <p className="text-base italic leading-relaxed text-neutral-600 dark:text-mint/70">
                             "If you're not improving, you're falling behind."
                         </p>
-                        <footer className="mt-1.5 text-sm text-[#385144]/60 dark:text-[#C2D8C4]/40">
+                        <footer className="mt-1.5 text-sm text-brand/60 dark:text-mint/40">
                             — Chris Bumstead
                         </footer>
                     </blockquote>
@@ -69,10 +69,10 @@ export default function About() {
                 >
                     <Eyebrow>GitHub activity</Eyebrow>
 
-                    <h3 className="mt-4 text-2xl font-bold tracking-tight text-[#111] dark:text-[#F8F5F2] md:text-3xl">
+                    <h3 className="mt-4 text-2xl font-bold tracking-tight text-ink dark:text-surface md:text-3xl">
                         Contribution graph
                     </h3>
-                    <p className="mt-2 text-sm text-neutral-500 dark:text-[#C2D8C4]/40">
+                    <p className="mt-2 text-sm text-neutral-500 dark:text-mint/40">
                         Activity across all public repositories
                     </p>
 

--- a/src/sections/About/GithubCalendar.tsx
+++ b/src/sections/About/GithubCalendar.tsx
@@ -78,7 +78,7 @@ export default function GithubCalendar() {
 
             {tooltip && (
                 <div
-                    className="fixed z-50 pointer-events-none px-2.5 py-1.5 rounded-lg bg-[#F8F5F2] dark:bg-[#2e2e2e] border border-[#385144]/25 dark:border-[#C2D8C4]/15 text-xs text-[#1f3329] dark:text-[#C2D8C4] shadow-lg whitespace-nowrap"
+                    className="fixed z-50 pointer-events-none px-2.5 py-1.5 rounded-lg bg-surface dark:bg-[#2e2e2e] border border-brand/25 dark:border-mint/15 text-xs text-brand-dark dark:text-mint shadow-lg whitespace-nowrap"
                     style={{
                         left: Math.min(
                             window.innerWidth - 220,

--- a/src/sections/Contact/Contact.tsx
+++ b/src/sections/Contact/Contact.tsx
@@ -14,7 +14,7 @@ export default function Contact() {
     return (
         <Section
             id={SECTION_IDS.CONTACT}
-            className="border-t border-[#385144]/10 py-20 dark:border-[#C2D8C4]/10 md:py-28"
+            className="border-t border-brand/10 py-20 dark:border-mint/10 md:py-28"
         >
             <GlowBlob className="left-1/2 top-0 h-[440px] w-[600px] -translate-x-1/2 blur-3xl" />
 
@@ -25,10 +25,10 @@ export default function Contact() {
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.5, ease: "easeOut" }}
             >
-                <h2 className="text-4xl font-extrabold tracking-tight text-[#111] dark:text-[#F8F5F2] md:text-6xl">
+                <h2 className="text-4xl font-extrabold tracking-tight text-ink dark:text-surface md:text-6xl">
                     Let's work together.
                 </h2>
-                <p className="mt-4 text-base text-neutral-500 dark:text-[#C2D8C4]/50 md:text-lg">
+                <p className="mt-4 text-base text-neutral-500 dark:text-mint/50 md:text-lg">
                     Open to internships, collaborations, and interesting
                     problems.
                 </p>

--- a/src/sections/Experience/Experience.tsx
+++ b/src/sections/Experience/Experience.tsx
@@ -17,10 +17,10 @@ export default function Experience() {
             <div className="relative mx-auto max-w-6xl">
                 {/* Header */}
                 <Eyebrow>Experience</Eyebrow>
-                <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-[#111] dark:text-[#F8F5F2] md:text-5xl">
+                <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-ink dark:text-surface md:text-5xl">
                     My journey
                 </h2>
-                <p className="mt-3 text-base text-neutral-500 dark:text-[#C2D8C4]/50 md:text-lg">
+                <p className="mt-3 text-base text-neutral-500 dark:text-mint/50 md:text-lg">
                     Education and internships across Europe.
                 </p>
 
@@ -34,7 +34,7 @@ export default function Experience() {
                         {railYears.map((year, i) => (
                             <span
                                 key={year}
-                                className="text-3xl font-extrabold tracking-tight text-[#385144] dark:text-[#C2D8C4]"
+                                className="text-3xl font-extrabold tracking-tight text-brand dark:text-mint"
                                 style={{
                                     opacity:
                                         1 -
@@ -47,7 +47,7 @@ export default function Experience() {
                     </div>
 
                     {/* Cards */}
-                    <div className="flex flex-col gap-6 md:border-l-2 md:border-[#385144]/10 md:pl-10 md:dark:border-[#C2D8C4]/10">
+                    <div className="flex flex-col gap-6 md:border-l-2 md:border-brand/10 md:pl-10 md:dark:border-mint/10">
                         {allEntries.map((exp, idx) => (
                             <ExperienceCard
                                 key={idx}

--- a/src/sections/Experience/ExperienceCard.tsx
+++ b/src/sections/Experience/ExperienceCard.tsx
@@ -59,36 +59,36 @@ export default function ExperienceCard({
         >
             {/* Timeline dot */}
             <span
-                className={`absolute -left-[41px] top-7 hidden h-3 w-3 rounded-full ring-4 ring-[#F8F5F2] dark:ring-[#1c1c1c] md:block ${
+                className={`absolute -left-[41px] top-7 hidden h-3 w-3 rounded-full ring-4 ring-surface dark:ring-[#1c1c1c] md:block ${
                     current
-                        ? "bg-[#385144] dark:bg-[#C2D8C4]"
-                        : "bg-[#385144]/30 dark:bg-[#C2D8C4]/30"
+                        ? "bg-brand dark:bg-mint"
+                        : "bg-brand/30 dark:bg-mint/30"
                 }`}
             />
 
             <div
                 className={`overflow-hidden rounded-2xl border p-5 transition-shadow duration-300 md:p-6 ${
                     current
-                        ? "border-[#385144]/25 dark:border-[#C2D8C4]/20 bg-white dark:bg-[#262626] shadow-[0_6px_28px_-6px_rgba(56,81,68,0.18)]"
-                        : "border-[#385144]/12 dark:border-[#C2D8C4]/10 bg-[#385144]/[0.03] dark:bg-[#C2D8C4]/[0.03]"
+                        ? "border-brand/25 dark:border-mint/20 bg-white dark:bg-[#262626] shadow-[0_6px_28px_-6px_rgba(56,81,68,0.18)]"
+                        : "border-brand/12 dark:border-mint/10 bg-brand/[0.03] dark:bg-mint/[0.03]"
                 }`}
             >
                 {/* Header: date + category badge */}
                 <div className="flex items-start justify-between gap-4">
                     <div>
-                        <p className="text-[11px] font-semibold uppercase tracking-wide text-neutral-400 dark:text-[#C2D8C4]/40">
+                        <p className="text-[11px] font-semibold uppercase tracking-wide text-neutral-400 dark:text-mint/40">
                             {exp.year}
                         </p>
                         <h3
                             className={`mt-1 text-lg font-bold ${
                                 current
-                                    ? "text-[#111] dark:text-[#F8F5F2]"
-                                    : "text-neutral-700 dark:text-[#C2D8C4]/80"
+                                    ? "text-ink dark:text-surface"
+                                    : "text-neutral-700 dark:text-mint/80"
                             }`}
                         >
                             {exp.location}
                         </h3>
-                        <p className="mt-0.5 text-[13px] text-neutral-400 dark:text-[#C2D8C4]/40">
+                        <p className="mt-0.5 text-[13px] text-neutral-400 dark:text-mint/40">
                             {exp.country}
                         </p>
                     </div>
@@ -96,7 +96,7 @@ export default function ExperienceCard({
                         className={`shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-semibold ${
                             isInternship
                                 ? "border-[#4a8ccc]/25 bg-[#4a8ccc]/10 text-[#4a8ccc]"
-                                : "border-[#385144]/25 bg-[#385144]/10 text-[#385144] dark:border-[#C2D8C4]/25 dark:bg-[#C2D8C4]/10 dark:text-[#C2D8C4]"
+                                : "border-brand/25 bg-brand/10 text-brand dark:border-mint/25 dark:bg-mint/10 dark:text-mint"
                         }`}
                     >
                         {exp.category}
@@ -104,7 +104,7 @@ export default function ExperienceCard({
                 </div>
 
                 {/* Description */}
-                <p className="mt-3 max-w-3xl text-[13px] leading-relaxed text-neutral-600 dark:text-[#C2D8C4]/60">
+                <p className="mt-3 max-w-3xl text-[13px] leading-relaxed text-neutral-600 dark:text-mint/60">
                     {exp.description}
                 </p>
 
@@ -133,7 +133,7 @@ export default function ExperienceCard({
                         ))}
 
                         {current && (
-                            <span className="inline-flex items-center gap-1.5 self-end rounded-full bg-[#385144]/10 dark:bg-[#C2D8C4]/10 px-2.5 py-1 text-[11px] font-semibold text-[#385144] dark:text-[#C2D8C4]">
+                            <span className="inline-flex items-center gap-1.5 self-end rounded-full bg-brand/10 dark:bg-mint/10 px-2.5 py-1 text-[11px] font-semibold text-brand dark:text-mint">
                                 <PulseDot />
                                 Now
                             </span>

--- a/src/sections/Home/Home.tsx
+++ b/src/sections/Home/Home.tsx
@@ -29,27 +29,27 @@ export default function Home() {
                     transition={{ duration: 0.6, ease: "easeOut" }}
                 >
                     {/* Eyebrow */}
-                    <div className="inline-flex items-center gap-2 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/20 bg-[#385144]/[0.08] dark:bg-[#C2D8C4]/[0.08] px-3.5 py-1.5">
+                    <div className="inline-flex items-center gap-2 rounded-full border border-brand/20 dark:border-mint/20 bg-brand/[0.08] dark:bg-mint/[0.08] px-3.5 py-1.5">
                         <PulseDot />
-                        <span className="text-xs font-semibold text-[#385144] dark:text-[#C2D8C4]">
+                        <span className="text-xs font-semibold text-brand dark:text-mint">
                             Open to opportunities
                         </span>
                     </div>
 
                     {/* Headline */}
-                    <h1 className="mt-6 text-5xl font-extrabold leading-[1.05] tracking-tight text-[#111] dark:text-[#F8F5F2] sm:text-6xl lg:text-7xl">
+                    <h1 className="mt-6 text-5xl font-extrabold leading-[1.05] tracking-tight text-ink dark:text-surface sm:text-6xl lg:text-7xl">
                         Building
                         <br />
                         things that
                         <br />
-                        <span className="text-[#385144] dark:text-[#C2D8C4]">
+                        <span className="text-brand dark:text-mint">
                             matter.
                         </span>
                     </h1>
-                    <div className="mt-5 h-[5px] w-56 rounded-full bg-[#385144]/20 dark:bg-[#C2D8C4]/20" />
+                    <div className="mt-5 h-[5px] w-56 rounded-full bg-brand/20 dark:bg-mint/20" />
 
                     {/* Subtitle */}
-                    <p className="mt-6 max-w-md text-base leading-7 text-neutral-600 dark:text-[#C2D8C4]/60 md:text-lg">
+                    <p className="mt-6 max-w-md text-base leading-7 text-neutral-600 dark:text-mint/60 md:text-lg">
                         Software developer &amp; student at Epitech.
                         <br />
                         Systems work, networking, clean interfaces.
@@ -72,7 +72,7 @@ export default function Home() {
                             whileHover={{ scale: 1.03, y: -1 }}
                             whileTap={{ scale: 0.97 }}
                             transition={{ type: "spring", stiffness: 300, damping: 20 }}
-                            className="inline-flex items-center rounded-full border-[1.5px] border-[#385144]/35 dark:border-[#C2D8C4]/25 px-7 py-3.5 text-sm font-semibold text-[#385144] dark:text-[#C2D8C4] transition-colors duration-200 hover:bg-[#385144]/10 dark:hover:bg-[#C2D8C4]/10 touch-manipulation"
+                            className="inline-flex items-center rounded-full border-[1.5px] border-brand/35 dark:border-mint/25 px-7 py-3.5 text-sm font-semibold text-brand dark:text-mint transition-colors duration-200 hover:bg-brand/10 dark:hover:bg-mint/10 touch-manipulation"
                         >
                             Get in touch
                         </motion.a>
@@ -80,7 +80,7 @@ export default function Home() {
 
                     {/* Find me on */}
                     <div className="mt-8 flex flex-wrap items-center gap-3">
-                        <span className="text-[10px] font-bold uppercase tracking-wider text-neutral-400 dark:text-[#C2D8C4]/30">
+                        <span className="text-[10px] font-bold uppercase tracking-wider text-neutral-400 dark:text-mint/30">
                             Find me on
                         </span>
                         <Chip
@@ -108,7 +108,7 @@ export default function Home() {
                     transition={{ duration: 0.6, delay: 0.15, ease: "easeOut" }}
                 >
                     <div className="relative">
-                        <div className="h-64 w-64 overflow-hidden rounded-full border-4 border-[#385144]/15 dark:border-[#C2D8C4]/15 shadow-[0_32px_80px_-20px_rgba(56,81,68,0.4)] sm:h-72 sm:w-72">
+                        <div className="h-64 w-64 overflow-hidden rounded-full border-4 border-brand/15 dark:border-mint/15 shadow-[0_32px_80px_-20px_rgba(56,81,68,0.4)] sm:h-72 sm:w-72">
                             <img
                                 src="/photos/Hero/Hero.jpg"
                                 alt="Luca Martinet"
@@ -133,10 +133,10 @@ export default function Home() {
                                     }}
                                     className="w-[150px] rounded-xl bg-white dark:bg-[#2a2a2a] px-4 py-2.5 shadow-[0_3px_20px_rgba(0,0,0,0.08)] dark:shadow-[0_3px_20px_rgba(0,0,0,0.4)]"
                                 >
-                                    <p className="text-base font-bold text-[#385144] dark:text-[#C2D8C4]">
+                                    <p className="text-base font-bold text-brand dark:text-mint">
                                         {stat.value}
                                     </p>
-                                    <p className="text-[11px] text-neutral-400 dark:text-[#C2D8C4]/40">
+                                    <p className="text-[11px] text-neutral-400 dark:text-mint/40">
                                         {stat.label}
                                     </p>
                                 </motion.div>

--- a/src/sections/Projects/ProjectCard.tsx
+++ b/src/sections/Projects/ProjectCard.tsx
@@ -26,10 +26,10 @@ export default function ProjectCard({ project, featured }: Props) {
             <motion.article
                 whileHover={{ y: -4 }}
                 transition={{ type: "spring", stiffness: 300, damping: 24 }}
-                className="rounded-2xl border-[1.5px] border-[#385144]/28 dark:border-[#C2D8C4]/20 bg-[#385144]/[0.04] dark:bg-[#C2D8C4]/[0.04] p-6 shadow-[0_8px_32px_-8px_rgba(56,81,68,0.18)] md:p-7"
+                className="rounded-2xl border-[1.5px] border-brand/28 dark:border-mint/20 bg-brand/[0.04] dark:bg-mint/[0.04] p-6 shadow-[0_8px_32px_-8px_rgba(56,81,68,0.18)] md:p-7"
             >
                 <div className="flex items-start justify-between gap-4">
-                    <span className="inline-flex items-center gap-1.5 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/20 bg-[#385144]/10 dark:bg-[#C2D8C4]/10 px-3 py-1 text-xs font-semibold text-[#385144] dark:text-[#C2D8C4]">
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-brand/20 dark:border-mint/20 bg-brand/10 dark:bg-mint/10 px-3 py-1 text-xs font-semibold text-brand dark:text-mint">
                         <Star size={12} className="fill-current" />
                         Featured
                     </span>
@@ -37,7 +37,7 @@ export default function ProjectCard({ project, featured }: Props) {
                         href={project.githubUrl}
                         target="_blank"
                         rel="noreferrer"
-                        className="inline-flex items-center gap-1.5 rounded-full border border-[#385144]/20 dark:border-[#C2D8C4]/20 bg-[#385144]/[0.07] dark:bg-[#C2D8C4]/[0.05] px-3.5 py-1.5 text-[13px] font-medium text-[#385144] dark:text-[#C2D8C4]/80 transition-colors hover:bg-[#385144]/15 dark:hover:bg-[#C2D8C4]/10"
+                        className="inline-flex items-center gap-1.5 rounded-full border border-brand/20 dark:border-mint/20 bg-brand/[0.07] dark:bg-mint/[0.05] px-3.5 py-1.5 text-[13px] font-medium text-brand dark:text-mint/80 transition-colors hover:bg-brand/15 dark:hover:bg-mint/10"
                     >
                         <Github size={14} />
                         GitHub
@@ -45,10 +45,10 @@ export default function ProjectCard({ project, featured }: Props) {
                     </a>
                 </div>
 
-                <h3 className="mt-5 text-xl font-bold text-[#111] dark:text-[#F8F5F2] md:text-2xl">
+                <h3 className="mt-5 text-xl font-bold text-ink dark:text-surface md:text-2xl">
                     {project.title}
                 </h3>
-                <p className="mt-3 max-w-2xl text-[15px] leading-relaxed text-neutral-600 dark:text-[#C2D8C4]/60">
+                <p className="mt-3 max-w-2xl text-[15px] leading-relaxed text-neutral-600 dark:text-mint/60">
                     {project.description}
                 </p>
                 <Tags tags={project.tags} />
@@ -64,17 +64,17 @@ export default function ProjectCard({ project, featured }: Props) {
             aria-label={`${project.title} — open ${project.demoUrl ? "live demo" : "on GitHub"}`}
             whileHover={{ y: -4 }}
             transition={{ type: "spring", stiffness: 300, damping: 24 }}
-            className="group flex h-full flex-col rounded-2xl border border-[#385144]/14 dark:border-[#C2D8C4]/10 bg-[#385144]/[0.03] dark:bg-[#C2D8C4]/[0.03] p-5 transition-colors hover:border-[#385144]/25 dark:hover:border-[#C2D8C4]/20 hover:bg-[#385144]/[0.06] dark:hover:bg-[#C2D8C4]/[0.06]"
+            className="group flex h-full flex-col rounded-2xl border border-brand/14 dark:border-mint/10 bg-brand/[0.03] dark:bg-mint/[0.03] p-5 transition-colors hover:border-brand/25 dark:hover:border-mint/20 hover:bg-brand/[0.06] dark:hover:bg-mint/[0.06]"
         >
             <div className="flex items-start justify-between gap-4">
-                <h3 className="text-base font-bold text-[#111] dark:text-[#F8F5F2]">
+                <h3 className="text-base font-bold text-ink dark:text-surface">
                     {project.title}
                 </h3>
-                <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full border border-[#385144]/15 dark:border-[#C2D8C4]/15 bg-[#385144]/[0.07] dark:bg-[#C2D8C4]/[0.05] text-[#385144] dark:text-[#C2D8C4]/80 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5">
+                <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full border border-brand/15 dark:border-mint/15 bg-brand/[0.07] dark:bg-mint/[0.05] text-brand dark:text-mint/80 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5">
                     <ArrowUpRight size={14} />
                 </span>
             </div>
-            <p className="mt-2 flex-1 text-[13px] leading-relaxed text-neutral-600 dark:text-[#C2D8C4]/60">
+            <p className="mt-2 flex-1 text-[13px] leading-relaxed text-neutral-600 dark:text-mint/60">
                 {project.description}
             </p>
             <Tags tags={project.tags} />

--- a/src/sections/Projects/Projects.tsx
+++ b/src/sections/Projects/Projects.tsx
@@ -20,10 +20,10 @@ export default function Projects() {
                     transition={{ duration: 0.5, ease: "easeOut" }}
                 >
                     <Eyebrow>Selected work</Eyebrow>
-                    <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-[#111] dark:text-[#F8F5F2] md:text-5xl">
+                    <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-ink dark:text-surface md:text-5xl">
                         Things I've built
                     </h2>
-                    <p className="mt-3 text-base text-neutral-500 dark:text-[#C2D8C4]/50 md:text-lg">
+                    <p className="mt-3 text-base text-neutral-500 dark:text-mint/50 md:text-lg">
                         Systems, networking, and web tooling — all on GitHub.
                     </p>
                 </motion.header>

--- a/src/sections/Resume/Resume.tsx
+++ b/src/sections/Resume/Resume.tsx
@@ -19,7 +19,7 @@ export default function Resume() {
                 >
                     <div>
                         <Eyebrow>Résumé</Eyebrow>
-                        <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-[#111] dark:text-[#F8F5F2] md:text-5xl">
+                        <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-ink dark:text-surface md:text-5xl">
                             My CV
                         </h2>
                     </div>
@@ -45,7 +45,7 @@ export default function Resume() {
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true, amount: 0.1 }}
                     transition={{ duration: 0.5, delay: 0.1, ease: "easeOut" }}
-                    className="mt-10 overflow-hidden rounded-2xl border border-[#385144]/15 dark:border-[#C2D8C4]/10 bg-white dark:bg-[#262626] shadow-[0_8px_32px_-12px_rgba(56,81,68,0.18)]"
+                    className="mt-10 overflow-hidden rounded-2xl border border-brand/15 dark:border-mint/10 bg-white dark:bg-[#262626] shadow-[0_8px_32px_-12px_rgba(56,81,68,0.18)]"
                 >
                     <iframe
                         src={`${cvPath}#toolbar=0&navpanes=0&view=FitH`}
@@ -53,12 +53,12 @@ export default function Resume() {
                         style={{ aspectRatio: "595.5 / 842.25" }}
                         title="CV - Luca Martinet"
                     />
-                    <div className="border-t border-[#385144]/10 dark:border-[#C2D8C4]/10 p-4 text-center">
+                    <div className="border-t border-brand/10 dark:border-mint/10 p-4 text-center">
                         <a
                             href={cvPath}
                             target="_blank"
                             rel="noreferrer"
-                            className="inline-flex items-center gap-1.5 text-sm font-medium text-[#385144]/70 dark:text-[#C2D8C4]/50 transition-colors hover:text-[#385144] dark:hover:text-[#C2D8C4]"
+                            className="inline-flex items-center gap-1.5 text-sm font-medium text-brand/70 dark:text-mint/50 transition-colors hover:text-brand dark:hover:text-mint"
                         >
                             <ExternalLink size={14} />
                             Open PDF in new tab


### PR DESCRIPTION
## Summary
Removes the biggest maintainability smell from the audit: the brand palette was hardcoded as arbitrary Tailwind values (`text-[#385144] dark:text-[#C2D8C4]`) repeated ~165× across ~10 files.

- Define the palette once in Tailwind's `@theme` (`index.css`): `brand`, `brand-dark`, `mint`, `mint-hover`, `surface`, `surface-dark`, `ink`.
- Replace every brand hex with the generated token utilities (`text-brand`, `bg-surface`, `border-mint/20`, `bg-brand/[0.06]`, …) across sections, components, and the shared primitives.
- Normalize the footer's near-duplicate `#c2d8c3` to `mint`.

The GitHub calendar's quoted `"#hex"` theme strings were intentionally left untouched (they're JS values, not classes). One-off surfaces (`#262626`, `#2a2a2a`, `#1c1c1c`, `#151815`), the internship blue, footer greys, and the pulse green remain inline as they're genuinely single-use.

Now changing the green is a one-line edit instead of a repo-wide find/replace.

## Test plan
- [x] `tsc -b`, `npm run lint`, `npm run build` all pass
- [x] Preview verified pixel-identical in **light and dark** mode, clean console