### PR TITLE
ci: add lint + build GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Lint, type-check & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build (type-check + bundle)
+        run: npm run build


### PR DESCRIPTION
## Summary
Adds continuous integration so `main` and every PR are automatically checked — previously nothing ran on push and the only gate was running things locally.

`.github/workflows/ci.yml` runs on push/PR to `main`:
- `npm ci`
- `npm run lint` (ESLint)
- `npm run build` (`tsc -b` type-check + Vite bundle)

Concurrency-guarded so superseded runs cancel. **Checks-only** — deployment intentionally stays on the existing manual `npm run deploy` (gh-pages) flow; happy to add a Pages deploy job later if you want CI to own deploys too.

## Test plan
- [x] Workflow YAML validated; commands match local scripts (lint + build both pass locally)
- [ ] Confirm the check runs green on this PR